### PR TITLE
ARGO-309 Modifications on nagios messaging component

### DIFF
--- a/argo-msg-nagios.spec
+++ b/argo-msg-nagios.spec
@@ -8,7 +8,6 @@ Source: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-build
 BuildArch: noarch
 Requires: perl(GridMon) >= 1.0.70
-Requires: msg-utils
 Requires: perl(No::Worries)
 Obsoletes: msg-nagios-bridge
 
@@ -42,6 +41,7 @@ install --mode 644 ./msg-to-handler.sysconfig ${RPM_BUILD_ROOT}/etc/sysconfig/ms
 install --directory ${RPM_BUILD_ROOT}/etc/msg-to-handler.d
 install --mode 644 ./msg-to-handler.conf ${RPM_BUILD_ROOT}/etc
 install --directory ${RPM_BUILD_ROOT}/var/cache/msg/config-cache
+install --directory ${RPM_BUILD_ROOT}/var/cache/msg/broker-cache-file
 touch ${RPM_BUILD_ROOT}/var/cache/msg/config-cache/config.db
 install --directory ${RPM_BUILD_ROOT}/var/run/msg-to-handler
 install --directory ${RPM_BUILD_ROOT}/var/spool/%{name}/outgoing
@@ -72,6 +72,7 @@ rm -rf $RPM_BUILD_ROOT
 %config %attr(0644,root,root) /etc/msg-to-handler.conf
 %dir /etc/msg-to-handler.d
 %dir %attr(0770,nagios,nagios) /var/cache/msg/config-cache
+%dir %attr(0770,nagios,nagios) /var/cache/msg/broker-cache-file
 %dir %attr(0770,nagios,nagios) /var/run/msg-to-handler
 %dir %attr(0770,nagios,nagios) /var/spool/%{name}/outgoing
 %dir %attr(0770,nagios,nagios) /var/spool/%{name}/incoming

--- a/src/handle_service_check
+++ b/src/handle_service_check
@@ -7,7 +7,7 @@ handle_service_check - Handle a Nagios service check and put it into a on-disk m
 
 =head1 SYNOPSIS
 
-B<handle_service_check> [--dir I<PATH>] [--role I<ROLE>] [--send-to-msg I<1|0>]  [--local-metric-store I<1|0>] [--v]
+B<handle_service_check> [--dir I<PATH>] [--role I<ROLE>] [--send-to-msg I<1|0>] [--v]
 
 =head1 DESCRIPTION
 
@@ -30,10 +30,6 @@ A sample message could be :
 
 If I<--send-to-msg> is set to 1, messages are inserted into the output directory.
 Default value is 1.
-
-If I<--local-metric-store> is set to 1, messages are also inserted
-into the local metric store directory queue C</var/spool/nagios2metricstore/data>.
-Default value is 0.
 
 =cut
 
@@ -60,23 +56,21 @@ use Env qw(NAGIOS_HOSTNAME NAGIOS_SERVICEDESC NAGIOS_SERVICESTATE NAGIOS_SERVICE
 
 my $dir = "/var/spool/msg-nagios-bridge/outgoing-messages";
 my $role = 'site';
-my $localMetricStore = 0;
 my $sendToMsg = 1;
 my $verbose = 0;
 
 GetOptions(
     'dir=s'                => \$dir,
     'role=s'               => \$role,
-    'local-metric-store=i' => \$localMetricStore,
     'send-to-msg=i'        => \$sendToMsg,
     'v'                    => \$verbose,
-) or die("Usage: $0 [--dir PATH] [--role ROLE] [--local-metric-store 1|0] [--send-to-msg 1|0] [--v]\n");
+) or die("Usage: $0 [--dir PATH] [--role ROLE] [--send-to-msg 1|0] [--v]\n");
 
 die("Expected to be run within Nagios - no Environment variables set\n")
     unless defined($NAGIOS_SERVICEDESC);
 
 # exit if result shouldn't be sent to msg or local metric store
-exit if (!$sendToMsg && !$localMetricStore);
+exit if (!$sendToMsg);
 
 # exist if this is soft state
 exit if $NAGIOS_SERVICESTATETYPE eq "SOFT";
@@ -149,12 +143,5 @@ if ($sendToMsg) {
     $cache = Messaging::Message::Queue->new(type => 'DQS', path => $dir);
     nagios_debug("posting to $metadata->{destination}");
     print $message->wlcg_format() if $verbose;
-    $cache->add_message(Messaging::Message->new(body => $message->wlcg_format(), header => $metadata));
-}
-
-if ($localMetricStore) {
-    $dir = "/var/spool/nagios2metricstore/data";
-    nagios_debug("storing into $dir");
-    $cache = Messaging::Message::Queue->new(type => 'DQS', path => $dir);
     $cache->add_message(Messaging::Message->new(body => $message->wlcg_format(), header => $metadata));
 }

--- a/src/handle_service_check
+++ b/src/handle_service_check
@@ -72,7 +72,7 @@ GetOptions(
 die("Expected to be run within Nagios - no Environment variables set\n")
     unless defined($NAGIOS_SERVICEDESC);
 
-die("Please provide a tenant name using the paramater --tenant \n")
+die("Please provide a tenant name with the --tenant parameter\n")
     unless ($tenant);
 
 # exit if result shouldn't be sent to msg or local metric store

--- a/src/handle_service_check
+++ b/src/handle_service_check
@@ -7,7 +7,7 @@ handle_service_check - Handle a Nagios service check and put it into a on-disk m
 
 =head1 SYNOPSIS
 
-B<handle_service_check> [--dir I<PATH>] [--role I<ROLE>] [--send-to-msg I<1|0>] [--v]
+B<handle_service_check> [--dir I<PATH>] [--role I<ROLE>] [--send-to-msg I<1|0>] [--tenant I<TENANT>] [--v]
 
 =head1 DESCRIPTION
 
@@ -17,7 +17,7 @@ directory and then exits.
 
 Once the messages are prepared, they are stored it in a
 C<Messaging::Message::Queue> directory. If not provided, the directory
-defaults to C</var/spool/nagios-msg-bridge/outgoing-messages>.
+defaults to C</var/spool/argo-msg-nagios/outgoing-messages>.
 
 The role can be one of C<site>, C<roc>, C<project>, C<vo> and denotes
 if the Nagios is acting in a site, ROC, project or VO level monitoring
@@ -54,7 +54,9 @@ nagios_debug("started");
 
 use Env qw(NAGIOS_HOSTNAME NAGIOS_SERVICEDESC NAGIOS_SERVICESTATE NAGIOS_SERVICESTATETYPE NAGIOS_SERVICEOUTPUT NAGIOS_SERVICENOTES NAGIOS_LONGSERVICEOUTPUT NAGIOS__SERVICESITE_NAME NAGIOS__SERVICEMETRIC_NAME NAGIOS__SERVICESERVICE_FLAVOUR NAGIOS__SERVICESERVICE_URI NAGIOS__SERVICEVO NAGIOS__SERVICEROC NAGIOS__SERVICEENCRYPTED NAGIOS__SERVICEVO_FQAN NAGIOS__SERVICESERVER);
 
-my $dir = "/var/spool/msg-nagios-bridge/outgoing-messages";
+my $dir = "/var/spool/argo-msg-nagios/outgoing-messages";
+my $topicPrefix = "/topic/nagios.metricOutput";
+my $tenant = "";
 my $role = 'site';
 my $sendToMsg = 1;
 my $verbose = 0;
@@ -63,11 +65,15 @@ GetOptions(
     'dir=s'                => \$dir,
     'role=s'               => \$role,
     'send-to-msg=i'        => \$sendToMsg,
+    'tenant=s'             => \$tenant,
     'v'                    => \$verbose,
-) or die("Usage: $0 [--dir PATH] [--role ROLE] [--send-to-msg 1|0] [--v]\n");
+) or die("Usage: $0 [--dir PATH] [--role ROLE] [--send-to-msg 1|0] [--tenant TENANT] [--v]\n");
 
 die("Expected to be run within Nagios - no Environment variables set\n")
     unless defined($NAGIOS_SERVICEDESC);
+
+die("Please provide a tenant name using the paramater --tenant \n")
+    unless ($tenant);
 
 # exit if result shouldn't be sent to msg or local metric store
 exit if (!$sendToMsg);
@@ -137,7 +143,7 @@ my $metadata = {
 
 # logic taken from send_to_msg
 $site =~ s/\./_/g;
-$metadata->{destination} = "/topic/grid.probe.metricOutput.EGEE.$role.$site";
+$metadata->{destination} = "$topicPrefix.$tenant.$role.$site";
 
 if ($sendToMsg) {   
     $cache = Messaging::Message::Queue->new(type => 'DQS', path => $dir);

--- a/src/send_to_msg
+++ b/src/send_to_msg
@@ -24,14 +24,14 @@ generated Nagios configuration from SQLite based cache and publish it
 to the messaging system.
 
 If not provided, the directory defaults to
-C</var/spool/nagios-msg-bridge/outgoing/>.
+C</var/spool/argo-msg-nagios/outgoing/>.
 
 If configuration cache file is not provided, it defaults to:
 C</var/cache/msg/config-cache/config.db>. Configuration table
 defaults to: C<config_outgoing>.
 
 If not provided, the directory with alarms defaults to
-C</var/spool/nagios-msg-bridge/outgoing_alarms/>.
+C</var/spool/argo-msg-nagios/outgoing_alarms/>.
 
 In case it cannot send a message, a warning is issued and the message
 is moved to the "error queue", which can be controlled using
@@ -44,7 +44,8 @@ the I<msg-brokers> script. The broker on the command line takes
 precedence over those specified in the cache file.
 
 If not provided, the destination defaults to
-C</topic/grid.probe.metricOutput.EGEE>.  A destination is created by:
+C</topic/nagios.metricOutput>.  A destination is created by:
+  * append tenant's name
   * append the role (e.g. C<Site>, C<ROC>, C<Project>, C<VO>)
   * append C<.SITE_NAME> to the prefix.
 
@@ -100,15 +101,15 @@ use constant USAGE => "usage: $0 [ -v ] [ --dir I<qdirectory> ] [ --prefix I<des
   [ --config-cache I<file> ] [ --config-table I<table-name> ] [ --config-prefix I<destination prefix> ]
   [ --alarm-dir I<qdirectory> ] [ --alarm-prefix I<destination prefix> ] [--persistent]\n";
 use constant DEFAULT_BATCH_SIZE => 10000;
-use constant DEFAULT_DIR => '/var/spool/msg-nagios-bridge/outgoing';
-use constant DEFAULT_PREFIX => '/topic/grid.probe.metricOutput.EGEE';
-use constant DEFAULT_ALARM_DIR => '/var/spool/msg-nagios-bridge/outgoing_alarms';
-use constant DEFAULT_ALARM_PREFIX => '/topic/grid.probe.notification';
+use constant DEFAULT_DIR => '/var/spool/argo-msg-nagios/outgoing';
+use constant DEFAULT_PREFIX => '/topic/nagios.metricOutput';
+use constant DEFAULT_ALARM_DIR => '/var/spool/argo-msg-nagios/outgoing_alarms';
+use constant DEFAULT_ALARM_PREFIX => '/topic/nagios.probe.notification';
 use constant DEFAULT_CONFIG_CACHE => '/var/cache/msg/config-cache/config.db';
 use constant DEFAULT_CONFIG_TABLE => 'config_outgoing';
-use constant DEFAULT_CONFIG_PREFIX => '/topic/grid.config.metricOutput.EGEE';
-use constant DEFAULT_ERROR_DIR => '/var/spool/msg-nagios-bridge/undelivered-messages';
-use constant DEFAULT_OUTGOING_DIR => '/var/spool/msg-nagios-bridge/outgoing-messages';
+use constant DEFAULT_CONFIG_PREFIX => '/topic/nagios.config.metricOutput';
+use constant DEFAULT_ERROR_DIR => '/var/spool/argo-msg-nagios/undelivered-messages';
+use constant DEFAULT_OUTGOING_DIR => '/var/spool/argo-msg-nagios/outgoing-messages';
 use constant DEFAULT_BROKER_CACHE => '/var/cache/msg/broker-cache-file/broker-list';
 use constant TIMEOUT => 0.1;
 
@@ -220,7 +221,7 @@ sub file_message ($) {
     $object{message} = $msg->jsonify();
     $name = $Cache{errors}->add_message(Messaging::Message->new(
         header => {
-	    "destination" => "/queue/grid.error.messages",
+	    "destination" => "/queue/nagios.error.messages",
 	    "persistent"  => "true",
 	    "expires"     => 1000 * (time() + 604800), # 1 week
 	    "mig-type"    => "message-with-error",


### PR DESCRIPTION
- [x] Remove the local metric store functionality from nagios service_check event handler and comes in parallel with the changes that have already been applied on NCG. 
  [ ref Commit https://github.com/ARGOeu/argo-ncg-eudat/commit/d84fd146a908d723dde81d244d787df793cdf614 ]
- [x] Update directories where defined according to new package name.
- [x] Distinguish broker topics by using additional command option for tenant's name.
- [x] Add broker-cache-file dir in order to remove the msg-utils dependency. This is also needed so we can manually define and pass a broker endpoint to send_to_msg script.
